### PR TITLE
Fix deprecation warnings and handling of @. on Julia v0.7

### DIFF
--- a/src/MuladdMacro.jl
+++ b/src/MuladdMacro.jl
@@ -12,9 +12,9 @@ end
 
 function to_muladd(ex::Expr)
     if !isaddition(ex)
-        if ex.head == :macrocall && length(ex.args)==2 && ex.args[1] == Symbol("@__dot__")
+        if ex.head == :macrocall && length(ex.args)>=2 && ex.args[1] == Symbol("@__dot__")
             # expand @. macros first (enables use of @. inside of @muladd expression)
-            return to_muladd(Base.Broadcast.__dot__(ex.args[2]))
+            return to_muladd(Base.Broadcast.__dot__(last(ex.args)))
         else
             # if expression is no sum apply the reduction to its arguments
             return Expr(ex.head, to_muladd.(ex.args)...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,34 +2,45 @@ using MuladdMacro
 using Base.Test
 
 # Basic expressions
-@test macroexpand(:(@muladd a*b+c)) == :($(Base.muladd)(a, b, c))
-@test macroexpand(:(@muladd c+a*b)) == :($(Base.muladd)(a, b, c))
-@test macroexpand(:(@muladd b*a+c)) == :($(Base.muladd)(b, a, c))
-@test macroexpand(:(@muladd c+b*a)) == :($(Base.muladd)(b, a, c))
-
-# Multiple multiplications
-@test macroexpand(:(@muladd a*b+c*d)) == :($(Base.muladd)(a, b, c*d))
-@test macroexpand(:(@muladd a*b+c*d+e*f)) == :($(Base.muladd)(a, b,
-                                                              $(Base.muladd)(c, d, e*f)))
-@test macroexpand(:(@muladd a*(b*c+d)+e)) == :($(Base.muladd)(a,
-                                                              $(Base.muladd)(b, c, d), e))
-
-# Dot calls
-@test macroexpand(:(@. @muladd a*b+c)) == :($(Base.muladd).(a, b, c))
-@test macroexpand(:(@muladd @. a*b+c)) == :($(Base.muladd).(a, b, c))
-@test macroexpand(:(@muladd a.*b+c)) == :(a.*b+c)
-@test macroexpand(:(@muladd a*b.+c)) == :(a*b.+c)
-@test macroexpand(:(@muladd f.(a)*b+c)) == :($(Base.muladd)(f.(a), b, c))
-@test macroexpand(:(@muladd a*f.(b)+c)) == :($(Base.muladd)(a, f.(b), c))
-@test macroexpand(:(@muladd a*b+f.(c))) == :($(Base.muladd)(a, b, f.(c)))
-
-# Nested expressions
-@test macroexpand(:(@muladd f(x, y, z) = x*y+z)) == :(f(x, y, z) = $(Base.muladd)(x, y, z))
-@test macroexpand(:(@muladd function f(x, y, z) x*y+z end)) ==
-    :(function f(x, y, z) $(Base.muladd)(x, y, z) end)
-@test macroexpand(:(@muladd for i in 1:n z = x*i + y end)) ==
-    :(for i in 1:n z = $(Base.muladd)(x, i, y) end)
+@testset "Basic expressions" begin
+    @test @macroexpand(@muladd a*b+c) == :($(Base.muladd)(a, b, c))
+    @test @macroexpand(@muladd c+a*b) == :($(Base.muladd)(a, b, c))
+    @test @macroexpand(@muladd b*a+c) == :($(Base.muladd)(b, a, c))
+    @test @macroexpand(@muladd c+b*a) == :($(Base.muladd)(b, a, c))
+end
 
 # Additional factors
-@test macroexpand(:(@muladd a*b*c+d)) == :($(Base.muladd)(a, b*c, d))
-@test macroexpand(:(@muladd a*b*c*d+e)) == :($(Base.muladd)(a, b*c*d, e))
+@testset "Additional factors" begin
+    @test @macroexpand(@muladd a*b*c+d) == :($(Base.muladd)(a, b*c, d))
+    @test @macroexpand(@muladd a*b*c*d+e) == :($(Base.muladd)(a, b*c*d, e))
+end
+
+# Multiple multiplications
+@testset "Multiple multiplications" begin
+    @test @macroexpand(@muladd a*b+c*d) == :($(Base.muladd)(a, b, c*d))
+    @test @macroexpand(@muladd a*b+c*d+e*f) == :($(Base.muladd)(a, b,
+                                                                $(Base.muladd)(c, d, e*f)))
+    @test @macroexpand(@muladd a*(b*c+d)+e) == :($(Base.muladd)(a,
+                                                                $(Base.muladd)(b, c, d), e))
+end
+
+# Dot calls
+@testset "Dot calls" begin
+    @test @macroexpand(@. @muladd a*b+c) == :($(Base.muladd).(a, b, c))
+    @test @macroexpand(@muladd @. a*b+c) == :($(Base.muladd).(a, b, c))
+    @test @macroexpand(@muladd a.*b+c) == :(a.*b+c)
+    @test @macroexpand(@muladd a*b.+c) == :(a*b.+c)
+    @test @macroexpand(@muladd f.(a)*b+c) == :($(Base.muladd)(f.(a), b, c))
+    @test @macroexpand(@muladd a*f.(b)+c) == :($(Base.muladd)(a, f.(b), c))
+    @test @macroexpand(@muladd a*b+f.(c)) == :($(Base.muladd)(a, b, f.(c)))
+end
+
+# Nested expressions
+@testset "Nested expressions" begin
+    @test @macroexpand(@muladd f(x, y, z) = x*y+z) == :(f(x, y, z) =
+                                                        $(Base.muladd)(x, y, z))
+    @test @macroexpand(@muladd function f(x, y, z) x*y+z end) ==
+        :(function f(x, y, z) $(Base.muladd)(x, y, z) end)
+    @test @macroexpand(@muladd for i in 1:n z = x*i + y end) ==
+        :(for i in 1:n z = $(Base.muladd)(x, i, y) end)
+end


### PR DESCRIPTION
This PR fixes both deprecation warnings and the incorrect expansion of `@.` on Julia v0.7. The error was caused by the following change in Julia v0.7 (see https://github.com/JuliaLang/julia/blob/master/NEWS.md):

> * All macros receive an extra argument __source__::LineNumberNode which describes the parser location in the source file for the @ of the macro call.